### PR TITLE
Générer l'emoji dès la 1ère lettre tapée

### DIFF
--- a/remove_colon.js
+++ b/remove_colon.js
@@ -3,7 +3,7 @@ var removeColon = function(e) {
 	var previousChar = $(this).val().substring(selectionStart, selectionStart + 1);
 	var previousPreviousChar = $(this).val().substring(selectionStart - 1, selectionStart - 1 + 1);
 	// 13 : entrée
-	if (e.which == 13 && (previousChar == ":" || previousPreviousChar == ":")) {
+	if (e.which == 13 && previousChar == ":") {
 		e.stopImmediatePropagation();
 	}
 };


### PR DESCRIPTION
Salut et merci pour ton extension qui sauve des bébés chats.

Je me demande pourquoi tu [vérifies aussi le `previousPreviousChar` pour arrêter l'évènement lié à l'emoji](https://github.com/agallou/github-colon-emoji-chrome/blob/master/remove_colon.js#L6) ?

Actuellement, ceci fait que si on tape `:d<enter>`, on va aller à la ligne. Il faut taper `:da<enter>` pour bien générer `:dancer:` :dancer:
Si on ne vérifie plus ce caractère, on peut taper `:d<enter>` pour faire apparaître l'emoji, et `:<enter>` pour passer à la ligne. Je trouve ça plus pratique, d'où la mini PR.

A+,
Leimi
